### PR TITLE
#73 コンボ一覧画面で消費ゲージを表示する

### DIFF
--- a/laravel/resources/assets/js/components/views/combo/comboList.vue
+++ b/laravel/resources/assets/js/components/views/combo/comboList.vue
@@ -9,6 +9,7 @@
           <p>Stun : {{combo.stun}}</p>
           <p>Memo : {{combo.memo}}</p>
           <p>Character : {{combo.character.name}}</p>
+          <p>Meter : {{combo.meter}}</p>
         </router-link>
       </li>
     </ul>


### PR DESCRIPTION
コンボ一覧画面で消費ゲージを表示する

# Issue

#73 