### PR TITLE
#82 コンボ更新APIの作成と利用

### DIFF
--- a/app/Http/Controllers/Api/ComboController.php
+++ b/app/Http/Controllers/Api/ComboController.php
@@ -10,6 +10,7 @@ use Log;
 use DB;
 use Session;
 use App\Http\Requests\ComboStore;
+use App\Http\Requests\ComboUpdate;
 
 class ComboController extends Controller
 {
@@ -63,9 +64,28 @@ class ComboController extends Controller
         }
     }
 
-    public function update()
+    /**
+     * コンボ更新API
+     *
+     * @param ComboUpdate $request コンボ登録用リクエストパラメーター
+     */
+    public function update(ComboUpdate $request)
     {
-
+        try {
+            $newCombo = $request->all();
+            $UserInfo = Session::get('UserInfo');
+            $oldCombo = ComboService::find($newCombo['id'], $UserInfo[0]['id']);
+            if ($oldCombo['myComboFlg']) {
+                DB::transaction(function () use($oldCombo, $newCombo) {
+                    return ComboService::update($newCombo);
+                });
+            } else {
+                return response(['message' => 'invalid combo id'], 400);
+            }
+        } catch (Throwable $t) {
+            Log::error($t);
+            return response(['message' => 'internal server error'], 500);
+        }
     }
 
     /**

--- a/app/Http/Controllers/Api/ComboController.php
+++ b/app/Http/Controllers/Api/ComboController.php
@@ -76,7 +76,7 @@ class ComboController extends Controller
             $UserInfo = Session::get('UserInfo');
             $oldCombo = ComboService::find($newCombo['id'], $UserInfo[0]['id']);
             if ($oldCombo['myComboFlg']) {
-                DB::transaction(function () use($oldCombo, $newCombo) {
+                DB::transaction(function () use($newCombo) {
                     return ComboService::update($newCombo);
                 });
             } else {

--- a/app/Http/Requests/ComboUpdate.php
+++ b/app/Http/Requests/ComboUpdate.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ComboUpdate extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'combo' => 'required',
+            'damage' => 'required',
+            'stun' => 'required',
+            'meter' => 'required',
+        ];
+    }
+}

--- a/app/Service/ComboService.php
+++ b/app/Service/ComboService.php
@@ -109,6 +109,37 @@ class ComboService
     }
 
     /**
+     * コンボ更新
+     *
+     * @param array newCombo 更新をする新しいコンボ情報
+     * @return int コンボID
+     */
+    public function update(array $newCombo): int
+    {
+        // 更新するコンボを取得
+        $comboId = $newCombo['id'];
+        // コントローラで取得した情報を利用したかったがComboService::findが配列を返すため
+        // 関数内で再度取得する
+        $oldCombo = Combo::with('character', 'recipes.move')->find($comboId);
+        // コンボの情報を更新
+        $oldCombo->damage = $newCombo['damage'];
+        $oldCombo->stun = $newCombo['stun'];
+        $oldCombo->memo = $newCombo['memo'];
+        // 更新
+        $oldCombo->save();
+        // レシピは削除して、再作成する
+        Recipe::where('combo_id', $comboId)->delete();
+        foreach ($newCombo['combo'] as $key => $value) {
+            $model = new Recipe();
+            $model->combo_id = $comboId;
+            $model->move_id = $value['id'];
+            $model->order = $key;
+            $model->save();
+        }
+        return $comboId;
+    }
+
+    /**
      * レシピコレクションから技ゲージの合計値を返す
      *
      * @param $recipes

--- a/resources/assets/js/components/views/combo/comboEdit.vue
+++ b/resources/assets/js/components/views/combo/comboEdit.vue
@@ -3,11 +3,28 @@
     <h1>Combo Edit</h1>
     <p>{{ $route.params.id }}</p>
     <p>
-      <p>Damege : {{combo.damage}}</p>
-      <p>Stun : {{combo.stun}}</p>
-      <p>Memo : {{combo.memo}}</p>
       <p>Character : {{combo.character.name}}</p>
+      <h3>Input Combo</h3>
+      <span v-for="move in combo.combo">
+        {{move.name}}
+      </span>
+      </div>
+      <div class="moveList">
+        <div v-for="move in moves" class="move" :move-id="move.id" @click="setMove(move)">
+          {{move.name}}
+        </div>
+      </div>
+      <button @click.prevent="allDelete">All Delete</button>
+      <button @click.prevent="oneDelete">One Delete</button>
+      <h3>Input Total Damage</h3>
+      <input type="number" v-model="combo.damage" placeholder="Input Total Damage">
+      <h3>Input Total Stun</h3>
+      <input type="number" v-model="combo.stun" placeholder="Input Total Stun">
+      <p>Meter : {{combo.meter}}</p>
+      <h3>Input Memo</h3>
+      <textarea v-model="combo.memo" placeholder="Input Memo"></textarea>
     </p>
+    <p @click="updateCombo" v-if="combo.myComboFlg">update</p>
     <router-link :to="'/combos/' + $route.params.id">back combo detail</router-link>
   </section>
 </template>
@@ -15,6 +32,22 @@
 <style scoped>
   h1 {
     color: red;
+  }
+
+  textarea {
+    width: 100%;
+  }
+
+  .moveList {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
+    grid-column-gap: 10px;
+    grid-row-gap: 10px;
+  }
+
+  .move {
+    background-color: #00AC0D;
+    text-align: center;
   }
 </style>
 
@@ -26,6 +59,7 @@
       },
     data() {
       return {
+        moves: [],
         combo: {
           character: '',
         },
@@ -36,7 +70,39 @@
         axios.get('/api/combos/' + this.$route.params.id)
         .then(res =>  {
           this.combo = res.data;
+          // 描画後に追加されるコンボ情報をVueで追跡させる
+          this.$set(this.combo, 'combo', []);
+          for(let recipe of this.combo.recipes) {
+            this.combo.combo.push(recipe.move);
+          }
+          this.getMove();
         })
+      },
+      getMove() {
+        axios.get('/api/moves', {
+          params: {
+            characterId: this.combo.character_id,
+          }
+        })
+        .then(res =>  {
+          this.moves = res.data;
+        });
+      },
+      updateCombo() {
+        console.log(this.combo);
+        axios.put('/api/combos/' + this.combo.id, this.combo)
+        .then(res => {
+          console.log(res);
+        });
+      },
+      setMove(move) {
+        this.combo.combo.push(move);
+      },
+      allDelete() {
+        this.combo.combo = [];
+      },
+      oneDelete() {
+        this.combo.combo.pop();
       },
     }
   }


### PR DESCRIPTION
コンボ更新APIの作成

今回は作成と利用のため更新成功しても画面は変わりません。

## レビュー観点

- 更新について、コンボは詰めなおしてsave,レシピは削除して再登録で問題ないか
- コンボサービスのfindが配列を返すため、オブジェクトにキャストしたりして使ってみたがsave関数が無いと怒られるので、苦肉の策で再度取得しています（いい方法が見つからなかった）

# Issue

#82 