### PR TITLE
ユーザーAPI、メールアドレス変更追加

### DIFF
--- a/app/Http/Controllers/Api/UserController.php
+++ b/app/Http/Controllers/Api/UserController.php
@@ -3,8 +3,8 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\UserUpdate;
 use Log;
-use Request;
 use Session;
 use Throwable;
 use UserService;
@@ -16,13 +16,21 @@ use UserService;
 class UserController extends Controller
 {
     /**
-     * @param Request $request
+     * @param int $userId
+     * @param UserUpdate $request
      * @return \Illuminate\Contracts\Routing\ResponseFactory|\Symfony\Component\HttpFoundation\Response
      */
-    public function update(Request $request)
+    public function update(int $userId, UserUpdate $request)
     {
+        if ($userId !== intval(Session::get('UserInfo')[0]['id'])) {
+            return response(['message' => 'Forbidden'], 403);
+        }
+
+        if ($request->has('email') && UserService::checkDuplicate($userId, 'email', $request->get('email'))) {
+            return response(['message' => 'email duplicate : ' . $request->get('email')], 412);
+        }
+
         try {
-            $userId = Session::get('UserInfo')[0]['id'];
             return UserService::update($userId, $request->all());
         } catch (Throwable $t) {
             Log::error($t);

--- a/app/Http/Controllers/Api/UserController.php
+++ b/app/Http/Controllers/Api/UserController.php
@@ -3,6 +3,11 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use Log;
+use Request;
+use Session;
+use Throwable;
+use UserService;
 
 /**
  * Class UserController
@@ -10,5 +15,18 @@ use App\Http\Controllers\Controller;
  */
 class UserController extends Controller
 {
-
+    /**
+     * @param Request $request
+     * @return \Illuminate\Contracts\Routing\ResponseFactory|\Symfony\Component\HttpFoundation\Response
+     */
+    public function update(Request $request)
+    {
+        try {
+            $userId = Session::get('UserInfo')[0]['id'];
+            return UserService::update($userId, $request->all());
+        } catch (Throwable $t) {
+            Log::error($t);
+            return response(['message' => 'internal server error'], 500);
+        }
+    }
 }

--- a/app/Http/Requests/UserUpdate.php
+++ b/app/Http/Requests/UserUpdate.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UserUpdate extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'email' => 'email|max:45',
+        ];
+    }
+}

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -16,6 +16,6 @@ class User extends Model
      * @var array
      */
     protected $fillable = [
-        'login_id', 'password', 'email'
+        'email'
     ];
 }

--- a/app/Service/UserService.php
+++ b/app/Service/UserService.php
@@ -4,6 +4,7 @@ namespace App\Service;
 
 use App\Model\User;
 use Illuminate\Support\Facades\Hash;
+use Log;
 
 
 /**
@@ -34,5 +35,27 @@ class UserService
     public function find(string $loginId)
     {
         return User::where('login_id', $loginId)->first();
+    }
+
+    /**
+     * @param int $userId
+     * @param array $parameter
+     * @return bool
+     */
+    public function update(int $userId, array $parameter): bool
+    {
+        $user = User::find($userId);
+        if ($user->count() === 0) {
+            Log::error('invalid userId :' . $userId);
+            return false;
+        }
+
+        // パスワードはハッシュ化する。
+        $updateParameter = [];
+        if (isset($parameter['password'])) {
+            $updateParameter['password'] = Hash::make($parameter['password']);
+        }
+
+        return $user->fill(array_merge($updateParameter, $parameter))->save();
     }
 }

--- a/app/Service/UserService.php
+++ b/app/Service/UserService.php
@@ -49,7 +49,8 @@ class UserService
     }
 
     /**
-     * 指定ユーザー以外の値重複チェック
+     * Usersテーブルのデータに対し、指定ユーザー以外の重複チェックを行う。
+     * メールアドレス重複チェックなど、ログインユーザー以外の存在チェックで利用する。
      *
      * @param int $userId
      * @param string $column
@@ -58,6 +59,7 @@ class UserService
      */
     public function checkDuplicate(int $userId, string $column, string $value): bool
     {
+        // 指定ユーザー以外に、カラムとバリューのセットが存在すればtrueを返す。
         $user = User::where([
             ['id', '!=', $userId],
             [$column, $value]

--- a/app/Service/UserService.php
+++ b/app/Service/UserService.php
@@ -40,22 +40,29 @@ class UserService
     /**
      * @param int $userId
      * @param array $parameter
+     * @return int
+     */
+    public function update(int $userId, array $parameter): int
+    {
+        User::find($userId)->fill($parameter)->save();
+        return $userId;
+    }
+
+    /**
+     * 指定ユーザー以外の値重複チェック
+     *
+     * @param int $userId
+     * @param string $column
+     * @param string $value
      * @return bool
      */
-    public function update(int $userId, array $parameter): bool
+    public function checkDuplicate(int $userId, string $column, string $value): bool
     {
-        $user = User::find($userId);
-        if ($user->count() === 0) {
-            Log::error('invalid userId :' . $userId);
-            return false;
-        }
+        $user = User::where([
+            ['id', '!=', $userId],
+            [$column, $value]
+        ]);
 
-        // パスワードはハッシュ化する。
-        $updateParameter = [];
-        if (isset($parameter['password'])) {
-            $updateParameter['password'] = Hash::make($parameter['password']);
-        }
-
-        return $user->fill(array_merge($updateParameter, $parameter))->save();
+        return $user->count() > 0;
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -19,7 +19,8 @@ Route::get('sortList',  function() {
 */
 Route::post('login', 'Api\AuthController@login');
 Route::post('logout', 'Api\AuthController@logout');
-Route::resource('users', 'Api\AuthController', ['only' => ['store']]);
+Route::post('users', 'Api\AuthController', ['only' => ['store']]);
+Route::resource('users', 'Api\UserController', ['only' => ['update']]);
 Route::resource('games', 'Api\GameController', ['only' => ['index', 'show']]);
 Route::resource('combos', 'Api\ComboController', ['only' => ['index', 'store', 'show', 'update', 'destroy']]);
 Route::resource('moves', 'Api\MoveController', ['only' => ['index']]);

--- a/routes/api.php
+++ b/routes/api.php
@@ -19,7 +19,7 @@ Route::get('sortList',  function() {
 */
 Route::post('login', 'Api\AuthController@login');
 Route::post('logout', 'Api\AuthController@logout');
-Route::post('users', 'Api\AuthController', ['only' => ['store']]);
+Route::post('users', 'Api\AuthController@store');
 Route::resource('users', 'Api\UserController', ['only' => ['update']]);
 Route::resource('games', 'Api\GameController', ['only' => ['index', 'show']]);
 Route::resource('combos', 'Api\ComboController', ['only' => ['index', 'store', 'show', 'update', 'destroy']]);

--- a/tests/Feature/Api/UserControllerTest.php
+++ b/tests/Feature/Api/UserControllerTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\User;
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+class UserControllerTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /**
+     * @dataProvider updateDataProvider
+     * @param int $userId
+     * @param array $params
+     * @param int $status
+     */
+    public function testUpdate(int $userId, array $params, int $status)
+    {
+        $this->createTestUser();
+
+        $this->withSession(['UserInfo' => [['id' => $userId]]]);
+        $response = $this->json('PUT', '/api/users/1', $params);
+        $response->assertStatus($status);
+    }
+
+    /**
+     * updateAPI用テストデータ
+     * @return array
+     */
+    public function updateDataProvider()
+    {
+        return [
+            [1, ['email' => 'test'], 422],
+            [2, ['email' => 'test@example.com'], 403],
+            [1, ['email' => 'test@example.com'], 412],
+            [1, ['email' => 'admin@example.com'], 200]
+        ];
+    }
+
+    /**
+     * テストユーザー作成メソッド
+     */
+    private function createTestUser()
+    {
+        $user = new User();
+        $user->login_id = 'test';
+        $user->password = 'testtest';
+        $user->email = 'test@example.com';
+        $user->save();
+    }
+}


### PR DESCRIPTION
# レビュー観点
以下の設計思想の認識が合っているかどうか。
設計思想どおりに実装されているか。

# 設計
- 更新自体はfillを利用してシンプルに。
- ログインIDとメールアドレスはDB内重複チェックしてから更新という流れなので、ログインID更新も考えた作りにする。
- ステータスコードはそれっぽいやつ・・笑
- 使用イメージは`put /api/users/{id}`

# 実装
- 更新対象idとログインidの一致チェック
- emailが他ユーザーと重複していないかチェック
  - ログインIDでも利用できるように重複チェックメソッドは共通化
- 更新はfillで行い、不正パラメーターがきてもfillableでガード。
- 前回相談したとおり、ログイン中のユーザーに対する操作はUserControllerへ格納

# サービスわけについて
重複チェックをUserService::updateでやっても良かった
が、レスポンスとして重複エラーを返したいのであえてサービスを分けました。

update内に書いてしまうと、エラー内容の出し分けが困難
やったとしても複雑な実装になってしまうので。
（returnをmixedにするとか、throwでエラーメッセージを投げるなどやり方はあるが、実装としてあまりよろしくない。returnはintで統一するために別サービスへ