### PR TITLE
#147 Add ComboStatus to ComboListApi

### DIFF
--- a/app/Model/Combo.php
+++ b/app/Model/Combo.php
@@ -2,6 +2,7 @@
 
 namespace App\Model;
 
+use DB;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -34,6 +35,22 @@ class Combo extends Model
     public function comboStatuses()
     {
         return $this->hasMany('App\Model\ComboStatus');
+    }
+
+    /**
+     * コンボステータス絞り込み
+     * @param $query
+     * @param array $statusIds
+     * @return mixed
+     */
+    public function scopeComboStatus($query, array $statusIds)
+    {
+        return $query->whereExists(function ($query) use ($statusIds) {
+            $query->select(DB::raw(1))
+                ->from('combo_statuses')
+                ->whereRaw('combo_statuses.combo_id = combos.id')
+                ->whereIn('status_id', $statusIds);
+        });
     }
 
     /**

--- a/app/Model/Combo.php
+++ b/app/Model/Combo.php
@@ -29,6 +29,14 @@ class Combo extends Model
     }
 
     /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function comboStatuses()
+    {
+        return $this->hasMany('App\Model\ComboStatus');
+    }
+
+    /**
      * キャラクターの絞り込み
      * @param $query クエリービルドインスタンス
      * @param $character_id キャラクターID

--- a/app/Model/ComboStatus.php
+++ b/app/Model/ComboStatus.php
@@ -7,4 +7,9 @@ use Illuminate\Database\Eloquent\Model;
 class ComboStatus extends Model
 {
     protected $fillable=['combo_id', 'status_id'];
+
+    public function status()
+    {
+        return $this->belongsTo('App\Model\Status');
+    }
 }

--- a/app/Service/ComboService.php
+++ b/app/Service/ComboService.php
@@ -48,6 +48,8 @@ class ComboService
     {
         $result = Combo::with('character', 'recipes.move')->find($id)->toArray();
         $result['meter'] = $this->sumMeter($result['recipes']);
+
+        // TODO: vuexを入れてフロントでユーザーIDを保持するようになったらいらないかも？
         // 自分の登録したコンボかチェックする
         $result['myComboFlg'] = $myUserId === $result['user_id'] ? true : false;
 
@@ -76,7 +78,7 @@ class ComboService
         }
 
         // コンボ取得
-        $resultList = $query->with('recipes.move')->get()->toArray();
+        $resultList = $query->with(['recipes.move', 'comboStatuses.status'])->get()->toArray();
 
         // 各コンボの技ゲージの合計値を計算し追加
         foreach ($resultList as &$result) {

--- a/app/Service/ComboService.php
+++ b/app/Service/ComboService.php
@@ -69,6 +69,11 @@ class ComboService
             $query = $query->character($params['characterId']);
         }
 
+        // コンボステータス絞り込み
+        if (isset($params['status'])) {
+            $query = $query->comboStatus($params['status']);
+        }
+
         // ソート
         $sort = Config::get('sort');
         if (isset($params['selectSortId']) && isset($sort[$params['selectSortId']])) {

--- a/tests/Feature/Api/ComboControllerTest.php
+++ b/tests/Feature/Api/ComboControllerTest.php
@@ -19,7 +19,19 @@ class ComboControllerTest extends TestCase
     public function testStore(array $params, int $status)
     {
         $this->withSession(['UserInfo' => [['id' => 1]]]);
-        $response = $this->json('POST', '/api/combos/', $params);
+        $response = $this->json('POST', '/api/combos', $params);
+        $response->assertStatus($status);
+    }
+
+    /**
+     * @dataProvider indexDataProvider
+     * @param array $params
+     * @param int $status
+     */
+    public function testIndex(array $params, int $status)
+    {
+        $this->withSession(['UserInfo' => [['id' => 1]]]);
+        $response = $this->json('GET', '/api/combos', $params);
         $response->assertStatus($status);
     }
 
@@ -29,6 +41,14 @@ class ComboControllerTest extends TestCase
             [['selectCharacterId' => 1, 'damage' => 100, 'stun' => 200, 'meter' => 0, 'memo' => 'test' , 'combo' => [1 => ['id' => 1]], 'status' => [1,2]], 200],
             [['selectCharacterId' => 1, 'damage' => 100, 'stun' => 200, 'meter' => 0, 'memo' => 'test' , 'combo' => [1 => ['id' => 1]]], 200],
             [['damage' => 100, 'stun' => 200, 'meter' => 0, 'memo' => 'test' , 'combo' => [1 => ['id' => 1]]], 422]
+        ];
+    }
+
+    public function indexDataProvider()
+    {
+        return [
+            [[], 200],
+            [['character_id' => 1], 200],
         ];
     }
 }

--- a/tests/Feature/Api/ComboControllerTest.php
+++ b/tests/Feature/Api/ComboControllerTest.php
@@ -49,6 +49,7 @@ class ComboControllerTest extends TestCase
         return [
             [[], 200],
             [['character_id' => 1], 200],
+            [['status' => [2]], 200],
         ];
     }
 }


### PR DESCRIPTION
コンボ登録APIとマイグレーションのPRが終わったら見てください。

# 概要
- コンボ一覧APIの戻り値にステータスを追加
- コンボ絞り込み時にステータスを追加

# 設計
## 戻り値追加
レシピと同じく、コンボ1つに対して複数のステータスが紐づくので
レシピと同じようにwithキーワードで取得

## 絞り込み
サブクエリーが必要なので絞り込みの操作はComboモデル内にスコープを実装
利用側は絞り込みたいステータスを渡せば絞りこめる
ステータスは複数でAND検索できるので、whereInで実装