### PR TITLE
#161 add api login middleware

### DIFF
--- a/app/Http/Middleware/CheckLogin.php
+++ b/app/Http/Middleware/CheckLogin.php
@@ -3,6 +3,8 @@
 namespace App\Http\Middleware;
 
 use Closure;
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Pagination\Paginator;
 use Session;
 
 class CheckLogin
@@ -10,19 +12,24 @@ class CheckLogin
     /**
      * Handle an incoming request.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \Closure  $next
+     * @param  \Illuminate\Http\Request $request
+     * @param  \Closure $next
+     * @param string $mode
      * @return mixed
+     * @throws AuthenticationException
      */
-    public function handle($request, Closure $next)
+    public function handle($request, Closure $next, string $mode = 'web')
     {
-
         // セッションにユーザー情報が入っていた場合表示する
         if (Session::has('UserInfo') && isset(Session::get('UserInfo')[0]) && isset(Session::get('UserInfo')[0]['id'])) {
             return $next($request);
         }
 
         // 入っていない場合はTOPにリダイレクト
-        return redirect('/');
+        if ($mode === 'api') {
+            throw new AuthenticationException('Unauthenticated.');
+        } else {
+            return redirect('/');
+        }
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -17,12 +17,16 @@ Route::get('sortList',  function() {
 | is assigned the "api" middleware group. Enjoy building your API!
 |
 */
+
 Route::post('login', 'Api\AuthController@login');
-Route::post('logout', 'Api\AuthController@logout');
 Route::post('users', 'Api\AuthController@store');
-Route::resource('users', 'Api\UserController', ['only' => ['update']]);
-Route::resource('games', 'Api\GameController', ['only' => ['index', 'show']]);
-Route::resource('combos/statuses', 'Api\Combos\StatusController', ['only' => ['index']]);
-Route::resource('combos', 'Api\ComboController', ['only' => ['index', 'store', 'show', 'update', 'destroy']]);
-Route::resource('moves', 'Api\MoveController', ['only' => ['index']]);
-Route::resource('characters', 'Api\CharacterController', ['only' => ['index', 'show']]);
+
+Route::group(['middleware' => 'login:api'], function () {
+    Route::post('logout', 'Api\AuthController@logout');
+    Route::resource('users', 'Api\UserController', ['only' => ['update']]);
+    Route::resource('games', 'Api\GameController', ['only' => ['index', 'show']]);
+    Route::resource('combos/statuses', 'Api\Combos\StatusController', ['only' => ['index']]);
+    Route::resource('combos', 'Api\ComboController', ['only' => ['index', 'store', 'show', 'update', 'destroy']]);
+    Route::resource('moves', 'Api\MoveController', ['only' => ['index']]);
+    Route::resource('characters', 'Api\CharacterController', ['only' => ['index', 'show']]);
+});

--- a/tests/Feature/Api/CharacterControllerTest.php
+++ b/tests/Feature/Api/CharacterControllerTest.php
@@ -12,6 +12,7 @@ class CharacterControllerTest extends TestCase
 {
     public function testIndexGameId1()
     {
+        $this->login();
         $response = $this->json('GET', '/api/characters/?gameId=1');
         $response->assertStatus(200);
         $response->assertJson([
@@ -25,6 +26,7 @@ class CharacterControllerTest extends TestCase
 
     public function testIndexGameId2()
     {
+        $this->login();
         $response = $this->json('GET', '/api/characters/?gameId=2');
         $response->assertStatus(200);
         $response->assertJson([
@@ -38,6 +40,7 @@ class CharacterControllerTest extends TestCase
 
     public function testValidatorGameId3()
     {
+        $this->login();
         $response = $this->json('GET', '/api/characters/?gameId=3');
         $response->assertStatus(400);
         $response->assertJson([
@@ -47,6 +50,7 @@ class CharacterControllerTest extends TestCase
 
     public function testValidatorGameIdNoNum()
     {
+        $this->login();
         $response = $this->json('GET', '/api/characters/?gameId=a');
         $response->assertStatus(400);
         $response->assertJson([
@@ -56,6 +60,7 @@ class CharacterControllerTest extends TestCase
 
     public function testValidatorNoGameId()
     {
+        $this->login();
         $response = $this->json('GET', '/api/characters/');
         $response->assertStatus(400);
         $response->assertJson([

--- a/tests/Feature/Api/ComboControllerTest.php
+++ b/tests/Feature/Api/ComboControllerTest.php
@@ -18,7 +18,7 @@ class ComboControllerTest extends TestCase
      */
     public function testStore(array $params, int $status)
     {
-        $this->withSession(['UserInfo' => [['id' => 1]]]);
+        $this->login();
         $response = $this->json('POST', '/api/combos', $params);
         $response->assertStatus($status);
     }
@@ -30,7 +30,7 @@ class ComboControllerTest extends TestCase
      */
     public function testIndex(array $params, int $status)
     {
-        $this->withSession(['UserInfo' => [['id' => 1]]]);
+        $this->login();
         $response = $this->json('GET', '/api/combos', $params);
         $response->assertStatus($status);
     }
@@ -42,7 +42,7 @@ class ComboControllerTest extends TestCase
      */
     public function testShow(int $comboId, int $status)
     {
-        $this->withSession(['UserInfo' => [['id' => 1]]]);
+        $this->login();
         $response = $this->json('GET', '/api/combos/' . $comboId);
         $response->assertStatus($status);
     }
@@ -54,7 +54,7 @@ class ComboControllerTest extends TestCase
      */
     public function testUpdate(array $params, int $status)
     {
-        $this->withSession(['UserInfo' => [['id' => 1]]]);
+        $this->login();
         $response = $this->json('PUT', '/api/combos/' . $params['id'], $params);
         $response->assertStatus($status);
     }
@@ -66,7 +66,7 @@ class ComboControllerTest extends TestCase
      */
     public function testDelete(int $comboId, int $status)
     {
-        $this->withSession(['UserInfo' => [['id' => 1]]]);
+        $this->login();
         $response = $this->json('DELETE', '/api/combos/' . $comboId);
         $response->assertStatus($status);
     }

--- a/tests/Feature/Api/GameControllerTest.php
+++ b/tests/Feature/Api/GameControllerTest.php
@@ -12,6 +12,7 @@ class GameControllerTest extends TestCase
 {
     public function testIndex()
     {
+        $this->login();
         $response = $this->json('GET', '/api/games');
         $response->assertStatus(200);
         $response->assertJson([
@@ -25,6 +26,7 @@ class GameControllerTest extends TestCase
 
     public function testShow()
     {
+        $this->login();
         $response = $this->json('GET', '/api/games/1');
         $response->assertStatus(200);
         $response->assertJson([
@@ -34,6 +36,7 @@ class GameControllerTest extends TestCase
 
     public function testShow400()
     {
+        $this->login();
         $response = $this->json('GET', '/api/games/0');
         $response->assertStatus(400);
         $response->assertJson([
@@ -43,6 +46,7 @@ class GameControllerTest extends TestCase
 
     public function testShow500()
     {
+        $this->login();
         $response = $this->json('GET', '/api/games/AAA');
         $response->assertStatus(500);
         $response->assertJson([

--- a/tests/Feature/Api/UserControllerTest.php
+++ b/tests/Feature/Api/UserControllerTest.php
@@ -20,7 +20,7 @@ class UserControllerTest extends TestCase
     {
         $this->createTestUser();
 
-        $this->withSession(['UserInfo' => [['id' => $userId]]]);
+        $this->login($userId);
         $response = $this->json('PUT', '/api/users/1', $params);
         $response->assertStatus($status);
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,4 +7,5 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
+    use TestTrait;
 }

--- a/tests/TestTrait.php
+++ b/tests/TestTrait.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tests;
+
+/**
+ * Trait TestTrait
+ * @package Tests
+ */
+trait TestTrait
+{
+    /**
+     * テスト用ログイン状態作成関数
+     * @param int $id
+     */
+    public function login(int $id = 1)
+    {
+        $this->withSession(['UserInfo' => [['id' => $id]]]);
+    }
+}


### PR DESCRIPTION
# 概要
APIにログイン認証を追加。
既存では外から叩けてしまうため。

# 設計
- web用のlogincheckをapiにも対応。
- テスト時にログイン状態を作り出すtraitを作成

# 注意
これがマージされると、apiが直接実行できなくなります。
一部のrest clientなど利用してcookieも一緒に送信するか
もしくは、開発時はmiddlewareをapi.webから外し
push前はテストコードで確認するなどがいいかもしれません。