### PR TITLE
#169 他人のコンボが編集できるバグの修正

### DIFF
--- a/resources/assets/js/components/views/combo/comboDetail.vue
+++ b/resources/assets/js/components/views/combo/comboDetail.vue
@@ -28,7 +28,7 @@
         <img src="/img/left-arrow.png" alt="left arrow">
         戻る
       </router-link>
-      <router-link class="combo__edit-link" :to="'/combos/' + $route.params.id + '/edit'">
+      <router-link v-if="combo.myComboFlg" class="combo__edit-link" :to="'/combos/' + $route.params.id + '/edit'">
         <img src="/img/pen.png" alt="pen">
         編集
       </router-link>


### PR DESCRIPTION
コンボ詳細画面で他人のコンボの編集ボタンが表示されていたため修正

# Issue

#169 