### PR TITLE
コンボ編集画面へステータスの追加

### DIFF
--- a/resources/assets/js/components/views/combo/comboCreate.vue
+++ b/resources/assets/js/components/views/combo/comboCreate.vue
@@ -1,18 +1,18 @@
 <template>
   <section class="combo__create">
-    <comboInput :Combo="Combo"></comboInput>
+    <comboInput v-if="reset" v-model="inputCombo"></comboInput>
     <modal v-if="createModal" @close="createModal = false">
       <div slot="modal-contents">
         <h3>Create!</h3>
-        <p>Character : {{Combo.selectCharacterName}} / {{Combo.selectCharacterId}}</p>
+        <p>Character : {{inputCombo.selectCharacterName}} / {{inputCombo.selectCharacterId}}</p>
         <p>Combo</p>
-        <span v-for="move in Combo.combo">
+        <span v-for="move in inputCombo.combo">
           {{move.name}}
         </span>
-        <p>Damage : {{Combo.damage}}</p>
-        <p>Stun : {{Combo.stun}}</p>
-        <p>Mete : {{Combo.meter}}</p>
-        <p>Memo : {{Combo.memo}}</p>
+        <p>Damage : {{inputCombo.damage}}</p>
+        <p>Stun : {{inputCombo.stun}}</p>
+        <p>Mete : {{inputCombo.meter}}</p>
+        <p>Memo : {{inputCombo.memo}}</p>
         <router-link to="/combos">back combo list</router-link>
         <p @click="init">create combo</p>
       </div>
@@ -84,19 +84,14 @@
       return {
         createModal: false,
         errorModal: false,
-        Combo: {
-          character_id: '',
-          combo: [],
-          damage: '',
-          stun: '',
-          meter: '',
-          memo: '',
-        },
+        inputCombo: {},
+        defaultCombo: {},
+        reset: true,
       };
     },
     methods: {
       create() {
-        axios.post('/api/combos',this.Combo)
+        axios.post('/api/combos',this.inputCombo)
         .then(res => {
           this.createModal = true;
         })
@@ -106,13 +101,12 @@
       },
       init() {
         this.createModal = false;
-        for(let id in this.Combo) {
-          if(Array.isArray(this.Combo[id])) {
-            this.Combo[id] = [];
-          } else {
-            this.Combo[id] = '';
-          }
-        }
+
+        // TODO 他にいい方法を探す。。
+        this.reset = false;
+        this.$nextTick(function () {
+          this.reset = true;
+        });
       },
     },
   };

--- a/resources/assets/js/components/views/combo/comboCreate.vue
+++ b/resources/assets/js/components/views/combo/comboCreate.vue
@@ -85,7 +85,6 @@
         createModal: false,
         errorModal: false,
         inputCombo: {},
-        defaultCombo: {},
         reset: true,
       };
     },

--- a/resources/assets/js/components/views/combo/comboEdit.vue
+++ b/resources/assets/js/components/views/combo/comboEdit.vue
@@ -1,6 +1,6 @@
 <template>
   <section>
-    <comboInput :Combo="Combo" :disabledSelectCharacter="true"></comboInput>
+    <comboInput v-if="showComponent" v-model="inputCombo" :default-combo="Combo"></comboInput>
     <p @click="updateCombo" v-if="Combo.myComboFlg">update</p>
     <router-link :to="'/combos/' + $route.params.id">back combo detail</router-link>
   </section>
@@ -21,7 +21,9 @@
     data() {
       return {
         Combo: {},
-      }
+        inputCombo: {},
+        showComponent: false,
+      };
     },
     methods: {
       getCombo() {
@@ -33,11 +35,11 @@
           for(let recipe of this.Combo.recipes) {
             this.Combo.combo.push(recipe.move);
           }
+          this.showComponent = true;
         })
       },
       updateCombo() {
-        console.log(this.Combo);
-        axios.put('/api/combos/' + this.Combo.id, this.Combo)
+        axios.put('/api/combos/' + this.Combo.id, this.inputCombo)
         .then(res => {
           console.log(res);
         });


### PR DESCRIPTION
# 概要
コンボステータスを入力できるようにチェックボックスを追加。デザインは別issueであてる

# 設計
コンポーネントの役割を変更。外からの入力は初期値のみに限定する
- propsで初期値を受け取れる。
- v-modelで入力されたコンボを返す。

# その他リファクタなど
- 入力すべてが親へデータを送るトリガーなので、deep watchで入力ごとに親へ伝える
- 画像の初期値ロジックを修正
  - 既存ロジックだと、キャラクターIDは取得できているが、キャラクターAPIがまだ返却されていない状態でreturnまで言ってしまうと img/character/ をsrcで取得しにいって404が出る
- コンボ更新時、コンボAPI取得中にコンポーネントが描写されると初期値が設定できないため、フラグをたててコンボAPIの結果を取得してからコンポーネント描写に変更
- コンボ登録完了後に再度登録する場合、リセットが必要だが、現状だとうまくりせっとする方法がない・・
一旦v-ifを発火することで初期化とした。