### PR TITLE
コンボ作成画面、キャラ変更時にコンボの削除

### DIFF
--- a/resources/assets/js/components/common/combo-input.vue
+++ b/resources/assets/js/components/common/combo-input.vue
@@ -204,6 +204,11 @@
           this.$emit('input', inputCombo);
         },
         deep: true
+      },
+      'inputCombo.character_id'(newVal, oldVal) {
+        if (oldVal !== '' && newVal !== oldVal) {
+          this.allDelete()
+        }
       }
     },
     data() {


### PR DESCRIPTION
コンボ入力してからキャラ変更時にコンボが消える用に修正。
空文字チェックしているのは、コンボ更新画面でこのコンポーネントを呼出した時
キャラクターIDが空文字から更新対象キャラになるが
その時のwatchでコンボが消されないようにしている